### PR TITLE
mx check - Add performance

### DIFF
--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -21,7 +21,7 @@ The mx tool performs the commands described below.
 
 ### 3.1 mx check Command [version 9.10+]
 
-The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance recommendations.
+The `mx check` command checks the app MPR file for issues such as Errors, Warnings or Deprecations.
 
 {{% alert color="info" %}}
 The MPR file must be the same version as mx.
@@ -40,7 +40,6 @@ The `OPTIONS` are described in the table below:
 | `--help` | `-h` | Displays the help text and exits. |
 | `--warnings` | `-w` | Include warnings in the output |
 | `--deprecations` | `-d` | Include deprecations in the output |
-| `--performance` | `-p` | Include performance checks in the output (performance recommendations are only output if there are no errors) |
 
 {{% alert color="info" %}}
 Errors in the MPR are always reported.
@@ -56,9 +55,7 @@ Examples of commands are described in the table below:
 | --- | --- |
 | `mx check --help` | Displays the help text for the check command. |
 | `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
-| `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings and deprecations. |
 
 #### 3.1.3 Return Codes
 
@@ -70,9 +67,8 @@ Return codes are described in the table below:
 | 1 | Errors were found. |
 | 2 | Warnings were found. |
 | 4 | Deprecations were found. |
-| 8 | Performance recommendations were found. |
 
-Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations, and performance recommendations.
+Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations.
 
 For example:
 - 3 if errors and warnings found

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -9,21 +9,19 @@ tags: ["mx", "command-line", "tool", "mx", "studio pro", "windows", "linux"]
 
 ## 1 Introduction
 
-The **mx tool** is a Windows and Linux command-line tool that can be used to do useful things with your Mendix app.
+The **mx tool** is a Windows and Linux command-line tool that can be used to perform various actions on a Mendix app.
 
 ## 2 Location
 
-Mendix Studio Pro comes with the mx command-line tool. The executable `mx.exe` file can be found in the same folder that contains `studiopro.exe` (for example, *C:\Program Files\Mendix\8.1.0.58215\modeler\mx.exe*).
+Mendix Studio Pro comes with the mx command-line tool. The executable `mx.exe` file can be found in the same folder that contains `studiopro.exe` (for example, *C:\Program Files\Mendix\9.12.2.44241\modeler\mx.exe*).
 
 ## 3 mx Tool Options
 
-The mx tool enables the options described below.
+The mx tool performs the commands described below.
 
 ### 3.1 mx check Command
 
-The `mx check` command checks the app for issues such as Errors, Warnings, Deprecations or Performance recommendations.
-
-The input is an MPR file.
+The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance recommendations.
 
 #### 3.1.1 Usage
 
@@ -36,9 +34,13 @@ The `OPTIONS` are described in the table below:
 | Option | Shortcut | Result |
 | --- | --- | --- |
 | `--help` | `-h` | Displays the help text and exits. |
-| `--warnings` | `-w` | Include warnings in the output (errors are always included) |
-| `--deprecations` | `-d` | Include deprecations in the output (errors are always included) |
-| `--performance` | `-p` | Include performance checks in the output (errors are always included) (performance recommendations are only output, if there are no errors) |
+| `--warnings` | `-w` | Include warnings in the output |
+| `--deprecations` | `-d` | Include deprecations in the output |
+| `--performance` | `-p` | Include performance checks in the output (performance recommendations are only output if there are no errors) |
+
+{{% alert color="info" %}}
+Errors in the MPR are always reported.
+{{% /alert %}}
 
 For `INPUT`, enter a single *.mpr* file.
 
@@ -51,35 +53,35 @@ Examples of commands are described in the table below:
 | `mx check --help` | Displays the help text for the check command. |
 | `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
 | `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings and deprecations. |
-| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, and deprecations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations, and performance recommendations. |
 
 #### 3.1.3 Return Codes
 
 Return codes are described in the table below:
 
-| Exit Code | Description |
+| Return Code | Description |
 | --- | --- |
 | 0 | No issues found. |
 | 1 | Errors were found. |
 | 2 | Warnings were found. |
-| 4 | Deprecations found. |
+| 4 | Deprecations were found. |
 | 8 | Performance recommendations were found. |
 
-Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations or performance recommendations.
+Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations, and performance recommendations.
 
 For example:
 - 3 if errors and warnings found
-- 7 if errors, warnings and deprecations found
+- 7 if errors, warnings, and deprecations found
 
 ### 3.2 mx convert Command
 
-The `mx convert` command converts the app(s) to a specific Studio Pro version. For example, if you are using the mx command-line tool for Mendix version 8.1.0.58215, then `mx convert` will convert the app to that version. 
+The `mx convert` command converts the app(s) MPK file(s) to a specific Studio Pro version. For example, if you are using the mx command-line tool for Mendix version 9.12.2.44241, then `mx convert` will convert the app to that version. 
 
 The input can be a single file, directory, or multiple files.
 
 {{% alert color="info" %}}
-The mx tool can only upgrade your app, but you cannot use it to downgrade the version.
+The mx tool can only upgrade your app; you cannot use it to downgrade the version.
 {{% /alert %}}
 
 #### 3.2.1 Usage
@@ -93,7 +95,7 @@ The `OPTIONS` are described in the table below:
 | Option | Shortcut | Result |
 | --- | --- | --- |
 | `--help` | `-h` | Displays the help text and exits. |
-| `--in-place` | `-p` | Converts the current app directory. Use this option to convert a folder containing a Mendix app. Otherwise, `mx convert` will convert *.mpk* files. |
+| `--in-place` | `-p` | Converts the current app directory. Use this option to convert a folder containing a Mendix app. Otherwise, `mx convert` will convert *.mpk* files. | 
 | `--skip-error-check` | `-s` | Does not check for errors. Use this option to disable app error-checking during the conversion. When omitted, the tool will report on the number of errors, warnings, and deprecations in the app and do the conversion. |
 
 For `INPUT...`, enter one or more *.mpk* files or one directory that needs to be converted.
@@ -109,7 +111,7 @@ Examples of commands are described in the table below:
 
 | Example | Result |
 | --- | --- |
-| `mx convert --in-place C:\MxProjects\App-main` | Converts the app in folder `C:\MxProjects\App-main` to a specific Studio Pro version which the mx tool is bundled with. |
+| `mx convert --in-place C:\MxProjects\App-main` | Converts the app in folder `C:\MxProjects\App-main` to the specific Studio Pro version which the mx tool is bundled with. |
 | `mx convert C:\Mendix\App1.mpk C:\Mendix\App2.mpk C:\Mendix\ConvertedProjects\` | Converts the *App1.mpk* and *App2.mpk* app packages that are in the *C:\Mendix\* folder and puts the results in the `C:\Mendix\ConvertedProjects\` folder. |
 | `mx convert --skip-error-check C:\Mendix\Packages\ C:\Mendix\ConvertedPackages\` | Converts all app packages in the `C:\Mendix\Packages\` folder to the `C:\Mendix\ConvertedPackages\` folder without checking for errors. |
 
@@ -117,7 +119,7 @@ Examples of commands are described in the table below:
 
 Return codes are described in the table below:
 
-| Exit Code | Description |
+| Return Code | Description |
 | --- | --- |
 | 0 | The conversion was successful. |
 | 1 | An internal error occurred. |
@@ -138,7 +140,7 @@ The `OPTIONS` are described in the table below:
 | --- | --- | --- |
 | `app-name` | App | Assigns the specified app name to the app. |
 | `output-dir` | Current directory | The directory in which to create the app. |
-| `language-code` | Optional | The default language of the app. |
+| `language-code` | Optional | The default language of the app. | 
 | `sprintr-app-id` | Optional | Associates the app [feedback features](/developerportal/collaborate/feedback/) with the provided [Developer Portal app](/developerportal/#my-apps). |
 
 `TEMPLATE-MPK-FILE` is an optional path to a Mendix app package (*.mpk*) file. If this argument is omitted, the app is created with a default empty project template.
@@ -157,16 +159,15 @@ Examples of commands are described in the table below:
 
 Return codes are described in the table below:
 
-| Exit Code | Description |
+| Return Code | Description |
 | --- | --- |
 | 0 | The app creation was successful. |
 | 1 | An internal error occurred. |
 | 2 | There is something wrong with the command-line options. |
 
-
 ### 3.4 mx show-version Command
 
-The `mx show-version` command reports on which version of Studio Pro was used to last open the app.
+The `mx show-version` command reports which version of Studio Pro was used last time the app was opened.
 
 The input is a single MPR file.
 
@@ -197,7 +198,7 @@ Examples of commands are described in the table below:
 
 Return codes are described in the table below:
 
-| Exit Code | Description |
+| Return Code | Description |
 | --- | --- |
 | 0 | The command ran successfully. |
 

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -19,15 +19,19 @@ Mendix Studio Pro comes with the mx command-line tool. The executable `mx.exe` f
 
 The mx tool performs the commands described below.
 
-### 3.1 mx check Command
+### 3.1 mx check Command [version 9.10+]
 
 The `mx check` command checks the app MPR file for issues such as Errors, Warnings, Deprecations or Performance recommendations.
+
+{{% alert color="info" %}}
+The MPR file must be the same version as mx.
+{{% /alert %}}
 
 #### 3.1.1 Usage
 
 Use the following command pattern for `mx check`:
 
-`mx convert [OPTIONS] INPUT`
+`mx check [OPTIONS] INPUT`
 
 The `OPTIONS` are described in the table below:
 
@@ -74,7 +78,7 @@ For example:
 - 3 if errors and warnings found
 - 7 if errors, warnings, and deprecations found
 
-### 3.2 mx convert Command
+### 3.2 mx convert Command [version 9+]
 
 The `mx convert` command converts the app(s) MPK file(s) to a specific Studio Pro version. For example, if you are using the mx command-line tool for Mendix version 9.12.2.44241, then `mx convert` will convert the app to that version. 
 
@@ -126,7 +130,7 @@ Return codes are described in the table below:
 | 2 | There is something wrong with the command-line options. |
 | 3 | Converting failed. |
 
-### 3.3 mx create-project Command
+### 3.3 mx create-project Command [version 9+]
 
 The `mx create-project` command creates a new app in the Studio Pro. The app version depends on the version the tool was bundled with. For example, if you are using the mx tool for Studio Pro version 8.1.0.58215,  `mx create project` will create a new app in that version. 
 
@@ -141,7 +145,7 @@ The `OPTIONS` are described in the table below:
 | `app-name` | App | Assigns the specified app name to the app. |
 | `output-dir` | Current directory | The directory in which to create the app. |
 | `language-code` | Optional | The default language of the app. | 
-| `sprintr-app-id` | Optional | Associates the app [feedback features](/developerportal/collaborate/feedback/) with the provided [Developer Portal app](/developerportal/#my-apps). |
+| `sprintr-app-id` | Optional | Associates the app [feedback features](/developerportal/collaborate/feedback/) with the provided [Developer Portal app](/developerportal/#my-apps). The value is a GUID. When accessing the app portal (on sprintr or on Team Server) it can be seen in the browser's URL - for example `1a428ea7-b00e-4166-9b23-20b7be88a40e`. |
 
 `TEMPLATE-MPK-FILE` is an optional path to a Mendix app package (*.mpk*) file. If this argument is omitted, the app is created with a default empty project template.
 
@@ -165,11 +169,15 @@ Return codes are described in the table below:
 | 1 | An internal error occurred. |
 | 2 | There is something wrong with the command-line options. |
 
-### 3.4 mx show-version Command
+### 3.4 mx show-version Command [version 9.4+]
 
 The `mx show-version` command reports which version of Studio Pro was used last time the app was opened.
 
 The input is a single MPR file.
+
+{{% alert color="info" %}}
+The MPR file must be the same version as mx.
+{{% /alert %}}
 
 #### 3.4.1 Usage
 

--- a/content/en/docs/refguide/general/mx-command-line-tool.md
+++ b/content/en/docs/refguide/general/mx-command-line-tool.md
@@ -19,7 +19,60 @@ Mendix Studio Pro comes with the mx command-line tool. The executable `mx.exe` f
 
 The mx tool enables the options described below.
 
-### 3.1 mx convert Command
+### 3.1 mx check Command
+
+The `mx check` command checks the app for issues such as Errors, Warnings, Deprecations or Performance recommendations.
+
+The input is an MPR file.
+
+#### 3.1.1 Usage
+
+Use the following command pattern for `mx check`:
+
+`mx convert [OPTIONS] INPUT`
+
+The `OPTIONS` are described in the table below:
+
+| Option | Shortcut | Result |
+| --- | --- | --- |
+| `--help` | `-h` | Displays the help text and exits. |
+| `--warnings` | `-w` | Include warnings in the output (errors are always included) |
+| `--deprecations` | `-d` | Include deprecations in the output (errors are always included) |
+| `--performance` | `-p` | Include performance checks in the output (errors are always included) (performance recommendations are only output, if there are no errors) |
+
+For `INPUT`, enter a single *.mpr* file.
+
+#### 3.1.2 Examples
+
+Examples of commands are described in the table below:
+
+| Example | Result |
+| --- | --- |
+| `mx check --help` | Displays the help text for the check command. |
+| `mx check C:\MxProjects\App-main\App-main.mpr` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors and performance recommendations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr --warnings --deprecations` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings and deprecations. |
+| `mx check C:\MxProjects\App-main\App-main.mpr -w -d -p` | Checks the app at `C:\MxProjects\App-main\App-main.mpr` for errors, warnings, deprecations and performance recommendations. |
+
+#### 3.1.3 Return Codes
+
+Return codes are described in the table below:
+
+| Exit Code | Description |
+| --- | --- |
+| 0 | No issues found. |
+| 1 | Errors were found. |
+| 2 | Warnings were found. |
+| 4 | Deprecations found. |
+| 8 | Performance recommendations were found. |
+
+Those values are logically OR combined to indicate when there are a mix of errors, warnings, deprecations or performance recommendations.
+
+For example:
+- 3 if errors and warnings found
+- 7 if errors, warnings and deprecations found
+
+### 3.2 mx convert Command
 
 The `mx convert` command converts the app(s) to a specific Studio Pro version. For example, if you are using the mx command-line tool for Mendix version 8.1.0.58215, then `mx convert` will convert the app to that version. 
 
@@ -29,7 +82,7 @@ The input can be a single file, directory, or multiple files.
 The mx tool can only upgrade your app, but you cannot use it to downgrade the version.
 {{% /alert %}}
 
-#### 3.1.1 Usage
+#### 3.2.1 Usage
 
 Use the following command pattern for `mx convert`:
 
@@ -50,7 +103,7 @@ For `OUTPUT`, enter the output location for the converted results. Mind the foll
 * When `INPUT...` is a single file, `OUTPUT` can be a single file or directory; otherwise, `OUTPUT` must be a directory.
 * When using the `--in-place` option, the `INPUT...` folder will also be used as the `OUTPUT` folder, so you do not need to specify a separate `OUTPUT` folder
 
-#### 3.1.2 Examples
+#### 3.2.2 Examples
 
 Examples of commands are described in the table below:
 
@@ -60,7 +113,7 @@ Examples of commands are described in the table below:
 | `mx convert C:\Mendix\App1.mpk C:\Mendix\App2.mpk C:\Mendix\ConvertedProjects\` | Converts the *App1.mpk* and *App2.mpk* app packages that are in the *C:\Mendix\* folder and puts the results in the `C:\Mendix\ConvertedProjects\` folder. |
 | `mx convert --skip-error-check C:\Mendix\Packages\ C:\Mendix\ConvertedPackages\` | Converts all app packages in the `C:\Mendix\Packages\` folder to the `C:\Mendix\ConvertedPackages\` folder without checking for errors. |
 
-#### 3.1.3 Return Codes 
+#### 3.2.3 Return Codes
 
 Return codes are described in the table below:
 
@@ -71,11 +124,11 @@ Return codes are described in the table below:
 | 2 | There is something wrong with the command-line options. |
 | 3 | Converting failed. |
 
-### 3.2 mx create-project Command
+### 3.3 mx create-project Command
 
 The `mx create-project` command creates a new app in the Studio Pro. The app version depends on the version the tool was bundled with. For example, if you are using the mx tool for Studio Pro version 8.1.0.58215,  `mx create project` will create a new app in that version. 
 
-#### 3.2.1 Usage
+#### 3.3.1 Usage
 
 Use the following command pattern: `mx create-project [OPTIONS] [TEMPLATE-MPK-FILE]`
 
@@ -90,7 +143,7 @@ The `OPTIONS` are described in the table below:
 
 `TEMPLATE-MPK-FILE` is an optional path to a Mendix app package (*.mpk*) file. If this argument is omitted, the app is created with a default empty project template.
 
-#### 3.2.2 Examples
+#### 3.3.2 Examples
 
 Examples of commands are described in the table below:
 
@@ -100,7 +153,7 @@ Examples of commands are described in the table below:
 | `mx create-project --app-name "MyFirstApp" --output-dir "C:/Projects/MyFirstApp"` | Creates an app named `MyFirstApp` in the *C:/Projects/MyFirstApp* folder using all the default parameters. |
 | `mx create-project "C:/Templates/ExpenseReportTemplate.mpk"` | Creates an app with the default parameters from a template located at *C:/Templates/ExpenseReportTemplate.mpk*. |
 
-#### 3.2.3 Return Codes 
+#### 3.3.3 Return Codes
 
 Return codes are described in the table below:
 
@@ -110,6 +163,44 @@ Return codes are described in the table below:
 | 1 | An internal error occurred. |
 | 2 | There is something wrong with the command-line options. |
 
-### 3.3 Undocumented Options
+
+### 3.4 mx show-version Command
+
+The `mx show-version` command reports on which version of Studio Pro was used to last open the app.
+
+The input is a single MPR file.
+
+#### 3.4.1 Usage
+
+Use the following command pattern for `mx show-version`:
+
+`mx show-version [OPTIONS] INPUT`
+
+The `OPTIONS` are described in the table below:
+
+| Option | Shortcut | Result |
+| --- | --- | --- |
+| `--help` | `-h` | Displays the help text and exits. |
+
+For `INPUT`, enter a *.mpr* file.
+
+#### 3.4.2 Examples
+
+Examples of commands are described in the table below:
+
+| Example | Result |
+| --- | --- |
+| `mx show-version --help` | Displays the help text for the `show-version` command. |
+| `mx show-version C:\Mendix\App1\App1.mpr` | Displays the version of Studio Pro that was last used to open the app. |
+
+#### 3.4.3 Return Codes
+
+Return codes are described in the table below:
+
+| Exit Code | Description |
+| --- | --- |
+| 0 | The command ran successfully. |
+
+### 3.5 Undocumented Options
 
 The mx tool contains options that are not described in this document. Those are for internal Mendix usage and are not officially supported. This might change in the future, but these options can be used only at your own risk.


### PR DESCRIPTION
Adds the `--performance` option to `mx check` command.

So, when `mx check` is run, the user can choose to include any performance recommendations in the check.

SP version: 9.16

* [ ] rebase when this other PR has been merged: https://github.com/mendix/docs/pull/4721 